### PR TITLE
Update .vimrc.bundles

### DIFF
--- a/.vimrc.bundles
+++ b/.vimrc.bundles
@@ -244,7 +244,6 @@
 
     " HTML {
         if count(g:spf13_bundle_groups, 'html')
-            Bundle 'amirh/HTML-AutoCloseTag'
             Bundle 'hail2u/vim-css3-syntax'
             Bundle 'gorodinskiy/vim-coloresque'
             Bundle 'tpope/vim-haml'


### PR DESCRIPTION
Removed the AutoCloseTag package since it interrupts installations asking for a Github username and password, and doesn't work at all if you have 2FA on your GitHub account. This package must be updated OR removed. I opt for removing it. Please merge this so other developers can have a seamless experience while using spf13-vim.